### PR TITLE
Update ConversationListAdapter.java

### DIFF
--- a/Android/TUIKit/TUIConversation/tuiconversation/src/main/java/com/tencent/qcloud/tuikit/tuiconversation/ui/view/ConversationListAdapter.java
+++ b/Android/TUIKit/TUIConversation/tuiconversation/src/main/java/com/tencent/qcloud/tuikit/tuiconversation/ui/view/ConversationListAdapter.java
@@ -376,12 +376,14 @@ public class ConversationListAdapter extends RecyclerView.Adapter implements ICo
     public void onItemRemoved(int position) {
         int itemIndex = getItemIndexInAdapter(position);
         notifyItemRemoved(itemIndex);
+        notifyItemRangeChanged(itemIndex,mDataSource.size()-position);
     }
 
     @Override
     public void onItemInserted(int position) {
         int itemIndex = getItemIndexInAdapter(position);
         notifyItemInserted(itemIndex);
+        notifyItemRangeChanged(itemIndex,mDataSource.size()-position);
     }
 
     @Override


### PR DESCRIPTION
修复会话列表 删除A会话后，再长按A会话下面其他的会话，下标异常导致闪退或者弹框位置错误
```java
    @Override
    public void onItemRemoved(int position) {
        int itemIndex = getItemIndexInAdapter(position);
        notifyItemRemoved(itemIndex);
         //保证会话下标正常
        notifyItemRangeChanged(itemIndex,mDataSource.size()-position);
    }

    @Override
    public void onItemInserted(int position) {
        int itemIndex = getItemIndexInAdapter(position);
        notifyItemInserted(itemIndex);
        //保证会话下标正常
        notifyItemRangeChanged(itemIndex,mDataSource.size()-position);
    }

```