### PR TITLE
Update TUIBaseChatViewController+AuthControl.m

### DIFF
--- a/iOS/TUIKit/TUIChat/UI/Chat/TUIBaseChatViewController+AuthControl.m
+++ b/iOS/TUIKit/TUIChat/UI/Chat/TUIBaseChatViewController+AuthControl.m
@@ -246,14 +246,12 @@
         
         PHAssetResourceRequestOptions *options = [[PHAssetResourceRequestOptions alloc] init];
         options.networkAccessAllowed = NO;
-        __block BOOL invoked = NO;
-        [PHAssetResourceManager.defaultManager requestDataForAssetResource:resources.firstObject options:options dataReceivedHandler:^(NSData * _Nonnull data) {
-            // 此处会有重复回调的问题
-            if (invoked) {
-                return;
-            }
-            invoked = YES;
-            if (data == nil) {
+        PHAssetResource *first = resources.firstObject;
+        NSMutableData *videoData = [NSMutableData data];
+        [PHAssetResourceManager.defaultManager requestDataForAssetResource:first options:options dataReceivedHandler:^(NSData * _Nonnull data) {
+            [videoData appendData:data];
+        } completionHandler:^(NSError * _Nullable error) {
+            if (error) {
                 completion(NO, nil);
                 return;
             }
@@ -264,10 +262,8 @@
                 [NSFileManager.defaultManager removeItemAtPath:filePath error:nil];
             }
             NSURL *newUrl = [NSURL fileURLWithPath:filePath];
-            BOOL flag = [NSFileManager.defaultManager createFileAtPath:filePath contents:data attributes:nil];
+            BOOL flag = [NSFileManager.defaultManager createFileAtPath:filePath contents:videoData attributes:nil];
             completion(flag, newUrl);
-        } completionHandler:^(NSError * _Nullable error) {
-            completion(NO, nil);
         }];
     }];
 }


### PR DESCRIPTION
1. fix:
问题描述：发送的视频消息不完整，10s视频，播3s左右就卡主不动了。
问题原因：此处并不是重复回调，而是分段请求文件回调，需要将所有回调数据拼接起来才是完整数据。
解决办法：在completionHandler回调中抛出完成回调。