### PR TITLE
修复id冲突

### DIFF
--- a/Android/TUIKit/TUIGroup/tuigroup/src/main/res/layout/group_info_layout.xml
+++ b/Android/TUIKit/TUIGroup/tuigroup/src/main/res/layout/group_info_layout.xml
@@ -180,15 +180,6 @@
             </LinearLayout>
 
             <com.tencent.qcloud.tuicore.component.LineControllerView
-                android:id="@+id/group_notice"
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/group_profile_item_height"
-                android:layout_marginTop="10dp"
-                android:visibility="gone"
-                app:name="@string/group_notice" />
-
-
-            <com.tencent.qcloud.tuicore.component.LineControllerView
                 android:id="@+id/group_manage"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/group_profile_item_height"


### PR DESCRIPTION
Android/TUIKit/TUIGroup/tuigroup/src/main/res/layout/group_info_layout.xml
布局文件中有两个名为 `group_notice` 同层级的同名id，在查验代码后发现是改版过程中历史遗留的，现提交 PR 移除无用的一个id