### PR TITLE
fix: [uniapp][TUIKit-vue2]聊天记录下拉刷新加载无新数据后，加载状态无法隐藏的问题

### DIFF
--- a/uni-app/TUIKit-vue2-js/components/tui-chat/message-list/index.vue
+++ b/uni-app/TUIKit-vue2-js/components/tui-chat/message-list/index.vue
@@ -125,10 +125,16 @@ export default {
 	methods: {
 		refresh() {
 			if (this.isCompleted) {
-				this.setData({
-					isCompleted: true,
-					triggered: false
-				});
+				// 修复下拉刷新加载中状态无法隐藏的问题
+				setTimeout(()=>{
+					this.triggered = true
+					this.$nextTick(() => {
+						this.setData({
+							isCompleted: true,
+							triggered: false
+						});
+					})
+				}, 500);
 				return;
 			}
 			this.getMessageList(this.conversation);


### PR DESCRIPTION
uni-app TUIKit 的 TUIKit-vue2-js 示例中
tui-chat/message-list 组件 scroll-view 下拉刷新。
当获取到最后一条历史记录后， scroll-view 的加载动画无法隐藏