### PR TITLE
事件反注册时，判断对象错误

### DIFF
--- a/iOS/TUIKit/TUICore/TUICore.m
+++ b/iOS/TUIKit/TUICore/TUICore.m
@@ -284,13 +284,13 @@ static const void *navigateValueCallback = @"navigateValueCallback";
             if (pObject == nil || [(TUIWeakProxy *)pObject target] == nil) {
                 [removeEventList addObject:event];
             }
-            if (key == nil && subKey == nil && pObject == object) {
+            if (key == nil && subKey == nil && pObject && [(TUIWeakProxy *)pObject target] == object) {
                 [removeEventList addObject:event];
             } else if ([pkey isEqualToString:key] && subKey == nil && object == nil) {
                 [removeEventList addObject:event];
             } else if ([pkey isEqualToString:key] && [subKey isEqualToString:pSubKey] && object == nil) {
                 [removeEventList addObject:event];
-            } else if ([pkey isEqualToString:key] && [subKey isEqualToString:pSubKey] && pObject == object) {
+            } else if ([pkey isEqualToString:key] && [subKey isEqualToString:pSubKey] && pObject && [(TUIWeakProxy *)pObject target] == object) {
                 [removeEventList addObject:event];
             }
         }


### PR DESCRIPTION
注册Event时使用了TUIWeakProxy来弱引用需要代理的对象
反注册Event不能直接使用pObject和object去比较
会导致取消注册失败