### PR TITLE
Fix potential vulnerable cloned functions

### DIFF
--- a/Windows/Demo/IMApp/zlib/inftrees.c
+++ b/Windows/Demo/IMApp/zlib/inftrees.c
@@ -185,9 +185,7 @@ unsigned short FAR *work;
         break;
     case LENS:
         base = lbase;
-        base -= 257;
         extra = lext;
-        extra -= 257;
         end = 256;
         break;
     default:            /* DISTS */
@@ -208,8 +206,8 @@ unsigned short FAR *work;
     mask = used - 1;            /* mask for comparing low */
 
     /* check available table space */
-    if ((type == LENS && used >= ENOUGH_LENS) ||
-        (type == DISTS && used >= ENOUGH_DISTS))
+    if ((type == LENS && used > ENOUGH_LENS) ||
+        (type == DISTS && used > ENOUGH_DISTS))
         return 1;
 
     /* process all codes and make table entries */
@@ -277,8 +275,8 @@ unsigned short FAR *work;
 
             /* check for enough space */
             used += 1U << curr;
-            if ((type == LENS && used >= ENOUGH_LENS) ||
-                (type == DISTS && used >= ENOUGH_DISTS))
+            if ((type == LENS && used > ENOUGH_LENS) ||
+                (type == DISTS && used > ENOUGH_DISTS))
                 return 1;
 
             /* point entry in root table to sub-table */


### PR DESCRIPTION
This PR fixes a potential vulnerability in inflate_table() that was cloned from zlib but did not receive the security patch. The original issue was reported and fixed under madler/zlib@6a04314. This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/cve-2016-9841
https://github.com/madler/zlib/commit/6a043145ca6e9c55184013841a67b2fef87e44c0